### PR TITLE
Fix JSON Deck Export

### DIFF
--- a/client/src/Hooks/useCopyJson.jsx
+++ b/client/src/Hooks/useCopyJson.jsx
@@ -14,7 +14,8 @@ export function useCopyJson({
       let num = card?.cardData?.Number;
       if (!set || !num) continue;
 
-      if (num >= 537 && num <= 774) num = (num - 510).toString();
+      if (num >= 265 && num <= 528) num = (num - 264).toString();
+      else if (num >= 537 && num <= 774) num = (num - 510).toString();
       else if (num >= 767 && num <= 1004) num = (num - 740).toString();
 
       num = num.toString().padStart(3, '0');

--- a/client/src/SealedPage/Components/Filter/FilterOptions.jsx
+++ b/client/src/SealedPage/Components/Filter/FilterOptions.jsx
@@ -86,7 +86,7 @@ export default function FilterOptions({ setFilteredCards, sortedCardPacks }) {
                 (selectedTypes.length === 0 ||
                   selectedTypes.includes(card?.cardData?.Type))) ||
               (selectedAspects.includes('Neutral') &&
-                card?.cardData?.Aspects.length === 0),
+                card?.cardData?.Aspects?.length === 0),
           ),
         );
       }
@@ -119,7 +119,7 @@ export default function FilterOptions({ setFilteredCards, sortedCardPacks }) {
                 selectedAspects.includes(aspect),
               ) ||
               (selectedAspects.includes('Neutral') &&
-                card?.cardData?.Aspects.length === 0) ||
+                card?.cardData?.Aspects?.length === 0) ||
               selectedCosts.includes(card?.cardData?.Cost) ||
               selectedRarities.includes(card?.cardData?.Rarity) ||
               selectedTypes.includes(card?.cardData?.Type),

--- a/client/src/SealedPage/Components/SealedPool.jsx
+++ b/client/src/SealedPage/Components/SealedPool.jsx
@@ -48,7 +48,15 @@ export default function SealedPool({
                 Number: c.cardData.Number - 510,
               },
             }
-          : c,
+          : c.cardData?.VariantType === 'Hyperspace'
+            ? {
+                ...c,
+                cardData: {
+                  ...c.cardData,
+                  Number: c.cardData.Number - 264,
+                },
+              }
+            : c,
       )
       .sort(
         (a, b) =>

--- a/server/app.js
+++ b/server/app.js
@@ -226,7 +226,7 @@ app.get('/api/foil', async (req, res) => {
           Type: { $ne: 'Leader' },
           VariantType: variant,
           Rarity: foilRarity,
-          $nor: [{ Rarity: 'common', Type: 'base' }],
+          $nor: [{ Rarity: 'Common', Type: 'Base' }],
         },
       },
       { $sample: { size: 1 } },


### PR DESCRIPTION
Actually removed common bases from the foil slot this time. Hyperspace cards in export are now combined with Normal as Foil and Hyperfoil were.